### PR TITLE
docs: add docs and code showing how to build xudt info

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ symbol: variable max 255
 ...
 
 ```
+**Notice: The format is NOT a key-value structure.**
+
+You can find code on how to construct the data in `generator-example/src/lumos.ts`
+```ts
+const coin = {
+  decimal: 6,
+  name: "UNIQUE COIN",
+  symbol: "UNC",
+};
+
+const data = bytes.hexify(bytes.concat(
+  Uint8.pack(coin.decimal),
+  Uint8.pack(coin.name.length),
+  new TextEncoder().encode(coin.name),
+  Uint8.pack(coin.symbol.length),
+  new TextEncoder().encode(coin.symbol),
+));
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ symbol: variable max 255
 ...
 
 ```
-**Notice: The format is NOT a key-value structure.**
+**Notice: The xUDT information format is NOT a key-value structure.**
 
 You can find code on how to construct the data in `generator-example/src/lumos.ts`
 ```ts

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ symbol: variable max 255
 ```
 **Notice: The xUDT information format is NOT a key-value structure.**
 
-You can find code on how to construct the data in `generator-example/src/lumos.ts`
+You can find the code about how to construct the xUDT information data in `generator-example/src/lumos.ts`
 ```ts
 const coin = {
   decimal: 6,

--- a/generator-example/src/lumos.ts
+++ b/generator-example/src/lumos.ts
@@ -1,5 +1,5 @@
 import { hd, utils, config, helpers, commons, RPC, Indexer, HashType, DepType, Input } from '@ckb-lumos/lumos';
-import { bytes, blockchain, Uint64 } from '@ckb-lumos/lumos/codec';
+import { bytes, blockchain, Uint8, Uint64 } from '@ckb-lumos/lumos/codec';
 
 // For test only, you should NEVER expose your mnemonic or privateKey in production
 export const tom = {
@@ -56,11 +56,22 @@ async function main() {
     ...UNIQUE_CELL.TESTNET.TYPE_SCRIPT,
     args: bytes.hexify(new Uint8Array(20)),   // 20 bytes placeholder
   };
-  const cell = helpers.cellHelper.create({
-    lock,
-    type,
-    data: bytes.hexify(new TextEncoder().encode("Unique Cell is Awesome!"))  // Relace with XUDT Info
-  });
+
+  const coin = {
+    decimal: 6,
+    name: "UNIQUE COIN",
+    symbol: "UNC",
+  };
+
+  const data = bytes.hexify(bytes.concat(
+    Uint8.pack(coin.decimal),
+    Uint8.pack(coin.name.length),
+    new TextEncoder().encode(coin.name),
+    Uint8.pack(coin.symbol.length),
+    new TextEncoder().encode(coin.symbol),
+  ));
+
+  const cell = helpers.cellHelper.create({ lock, type, data });
 
   let txSkeleton = helpers.TransactionSkeleton({ cellProvider: indexer });
   txSkeleton = helpers.addCellDep(txSkeleton, UNIQUE_CELL.TESTNET.CELL_DEP);


### PR DESCRIPTION
This PR adds docs and code on how to build the XUDT information.

Developers who are new to CKB may think the XUDT info is a key-value structure.
The docs help clarify the data structure.